### PR TITLE
Add client deletion confirmation and removal

### DIFF
--- a/lista_clientes.html
+++ b/lista_clientes.html
@@ -44,7 +44,7 @@
               <td>2025-08-01</td>
               <td>
                 <a href="editar.html" class="btn btn-sm btn-outline-primary me-1"><i class="bi bi-pencil-square"></i></a>
-                <button class="btn btn-sm btn-outline-danger"><i class="bi bi-trash"></i></button>
+                <button class="btn btn-sm btn-outline-danger" onclick="excluirCliente(1)"><i class="bi bi-trash"></i></button>
                 <button class="btn btn-sm btn-outline-info" data-bs-toggle="modal" data-bs-target="#historicoModal">
                   <i class="bi bi-clock-history"></i>
                 </button>
@@ -58,7 +58,7 @@
               <td>2025-07-25</td>
               <td>
                 <a href="editar.html" class="btn btn-sm btn-outline-primary me-1"><i class="bi bi-pencil-square"></i></a>
-                <button class="btn btn-sm btn-outline-danger"><i class="bi bi-trash"></i></button>
+                <button class="btn btn-sm btn-outline-danger" onclick="excluirCliente(2)"><i class="bi bi-trash"></i></button>
                 <button class="btn btn-sm btn-outline-info" data-bs-toggle="modal" data-bs-target="#historicoModal">
                   <i class="bi bi-clock-history"></i>
                 </button>
@@ -72,7 +72,7 @@
               <td>2025-07-10</td>
               <td>
                 <a href="editar.html" class="btn btn-sm btn-outline-primary me-1"><i class="bi bi-pencil-square"></i></a>
-                <button class="btn btn-sm btn-outline-danger"><i class="bi bi-trash"></i></button>
+                <button class="btn btn-sm btn-outline-danger" onclick="excluirCliente(3)"><i class="bi bi-trash"></i></button>
                 <button class="btn btn-sm btn-outline-info" data-bs-toggle="modal" data-bs-target="#historicoModal">
                   <i class="bi bi-clock-history"></i>
                 </button>
@@ -140,6 +140,19 @@
         });
       }
     });
+
+    function excluirCliente(id) {
+      if (confirm('Tem certeza que deseja excluir este cliente?')) {
+        const clientes = JSON.parse(localStorage.getItem('clientes')) || [];
+        const atualizados = clientes.filter(c => c.id !== id);
+        localStorage.setItem('clientes', JSON.stringify(atualizados));
+
+        const table = $('#tabelaClientes').DataTable();
+        table.rows(function (idx, data, node) {
+          return data[0] == id;
+        }).remove().draw();
+      }
+    }
   </script>
   <script src="layout.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add onclick delete handlers for each client row
- implement excluirCliente with confirmation, localStorage cleanup, and table refresh

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899f147d40c832db331a730d19f6e62