### PR TITLE
Fix sidebar active page highlight

### DIFF
--- a/layout.js
+++ b/layout.js
@@ -25,7 +25,13 @@ document.addEventListener('DOMContentLoaded', loadLayout);
 function highlightActiveSidebarLink() {
   // Get all nav-links inside the sidebar
   const links = document.querySelectorAll('.sidebar .nav-link[href]');
-  const currentPage = location.pathname.split('/').pop();
+  // Determine current page name, defaulting to index.html for root paths
+  let currentPage = window.location.pathname.split('/').pop();
+  if (!currentPage) {
+    currentPage = 'index.html';
+  }
+  // Remove possible query strings or hashes from the page name
+  currentPage = currentPage.split('?')[0].split('#')[0];
 
   links.forEach(link => {
     const linkHref = link.getAttribute('href');
@@ -41,6 +47,11 @@ function highlightActiveSidebarLink() {
       if (collapseParent) {
         const instance = bootstrap.Collapse.getOrCreateInstance(collapseParent, { toggle: false });
         instance.show();
+        // Also highlight the parent toggle link
+        const parentToggle = collapseParent.previousElementSibling;
+        if (parentToggle && parentToggle.classList.contains('nav-link')) {
+          parentToggle.classList.add('active');
+        }
       }
     }
   });


### PR DESCRIPTION
## Summary
- fix current page detection in sidebar to default to index and ignore query/hash
- highlight parent menu items when their submenu pages are active

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689afab268c8832d9beddd2eb414ed90