### PR TITLE
Fix submenu expansion to show only active section

### DIFF
--- a/layout.js
+++ b/layout.js
@@ -25,6 +25,7 @@ document.addEventListener('DOMContentLoaded', loadLayout);
 function highlightActiveSidebarLink() {
   // Get all nav-links inside the sidebar
   const links = document.querySelectorAll('.sidebar .nav-link[href]');
+  const collapses = document.querySelectorAll('.sidebar .collapse');
   // Determine current page name, defaulting to index.html for root paths
   let currentPage = window.location.pathname.split('/').pop();
   if (!currentPage) {
@@ -42,17 +43,20 @@ function highlightActiveSidebarLink() {
       const pageName = link.textContent.trim();
       document.title = `${pageName} | SIGE`;
 
-      // If it's inside a collapsed submenu, open it
       const collapseParent = link.closest('.collapse');
-      if (collapseParent) {
-        const instance = bootstrap.Collapse.getOrCreateInstance(collapseParent, { toggle: false });
-        instance.show();
-        // Also highlight the parent toggle link
-        const parentToggle = collapseParent.previousElementSibling;
-        if (parentToggle && parentToggle.classList.contains('nav-link')) {
-          parentToggle.classList.add('active');
+      collapses.forEach(collapse => {
+        const instance = bootstrap.Collapse.getOrCreateInstance(collapse, { toggle: false });
+        if (collapse === collapseParent) {
+          instance.show();
+          // Also highlight the parent toggle link
+          const parentToggle = collapse.previousElementSibling;
+          if (parentToggle && parentToggle.classList.contains('nav-link')) {
+            parentToggle.classList.add('active');
+          }
+        } else {
+          instance.hide();
         }
-      }
+      });
     }
   });
 }

--- a/sidebar.html
+++ b/sidebar.html
@@ -8,7 +8,7 @@
 <div class="sidebar bg-dark text-white position-fixed top-0 bottom-0 d-flex flex-column p-3">
   <h4 class="text-center">SIGE</h4>
   <hr>
-  <nav class="nav nav-pills flex-column">
+  <nav id="sidebar-menu" class="nav nav-pills flex-column">
     <a href="index.html" class="nav-link text-white" id="dashboard-link">
       <i class="bi bi-speedometer2 me-2"></i>Dashboard
     </a>
@@ -17,7 +17,7 @@
       <i class="bi bi-caret-down"></i>
     </a>
     <!-- Submenu de clientes -->
-    <div class="collapse ms-3" id="submenuClientes">
+    <div class="collapse ms-3" id="submenuClientes" data-bs-parent="#sidebar-menu">
       <a href="lista_clientes.html" class="nav-link text-white">Lista de Clientes</a>
       <a href="cadastrar.html" class="nav-link text-white">Cadastrar Cliente</a>
     </div>


### PR DESCRIPTION
## Summary
- Ensure only the active sidebar submenu is displayed by collapsing siblings
- Group sidebar collapses via `data-bs-parent` to enforce single open submenu

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689afc52d488832d9c88f109e7456e85