### PR TITLE
Corrige destaque do submenu Clientes

### DIFF
--- a/layout.js
+++ b/layout.js
@@ -26,6 +26,7 @@ function highlightActiveSidebarLink() {
   // Get all nav-links inside the sidebar
   const links = document.querySelectorAll('.sidebar .nav-link[href]');
   const collapses = document.querySelectorAll('.sidebar .collapse');
+
   // Determine current page name, defaulting to index.html for root paths
   let currentPage = window.location.pathname.split('/').pop();
   if (!currentPage) {
@@ -34,29 +35,45 @@ function highlightActiveSidebarLink() {
   // Remove possible query strings or hashes from the page name
   currentPage = currentPage.split('?')[0].split('#')[0];
 
+  // Clear previous active states
   links.forEach(link => {
-    const linkHref = link.getAttribute('href');
-    if (linkHref && linkHref === currentPage) {
-      link.classList.add('active');
-
-      // Update browser tab title based on active link text
-      const pageName = link.textContent.trim();
-      document.title = `${pageName} | SIGE`;
-
-      const collapseParent = link.closest('.collapse');
-      collapses.forEach(collapse => {
-        const instance = bootstrap.Collapse.getOrCreateInstance(collapse, { toggle: false });
-        if (collapse === collapseParent) {
-          instance.show();
-          // Also highlight the parent toggle link
-          const parentToggle = collapse.previousElementSibling;
-          if (parentToggle && parentToggle.classList.contains('nav-link')) {
-            parentToggle.classList.add('active');
-          }
-        } else {
-          instance.hide();
-        }
-      });
+    link.classList.remove('active');
+    link.removeAttribute('aria-current');
+  });
+  collapses.forEach(collapse => {
+    collapse.classList.remove('show');
+    const parentToggle = collapse.previousElementSibling;
+    if (parentToggle && parentToggle.classList.contains('nav-link')) {
+      parentToggle.classList.remove('active');
+      parentToggle.setAttribute('aria-expanded', 'false');
     }
   });
+
+  // Find the link that matches the current page
+  const activeLink = Array.from(links).find(link => {
+    const href = link.getAttribute('href');
+    return href && !href.startsWith('#') && href === currentPage;
+  });
+
+  if (activeLink) {
+    activeLink.classList.add('active');
+    activeLink.setAttribute('aria-current', 'page');
+
+    // Update browser tab title based on active link text
+    const pageName = activeLink.textContent.trim();
+    document.title = `${pageName} | SIGE`;
+
+    const collapseParent = activeLink.closest('.collapse');
+    if (collapseParent) {
+      const instance = bootstrap.Collapse.getOrCreateInstance(collapseParent, { toggle: false });
+      instance.show();
+
+      // Also highlight the parent toggle link
+      const parentToggle = collapseParent.previousElementSibling;
+      if (parentToggle && parentToggle.classList.contains('nav-link')) {
+        parentToggle.classList.add('active');
+        parentToggle.setAttribute('aria-expanded', 'true');
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- aplica classe `active` do Bootstrap para indicar página actual e expandir `Clientes`

## Testing
- `npm test` *(falhou: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689afddb31ec832d923cc5f06e2a3726