### PR TITLE
feat: add search and export options to products list

### DIFF
--- a/lista_produtos.html
+++ b/lista_produtos.html
@@ -6,6 +6,8 @@
   <title>Lista de Produtos | SIGE</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/buttons/2.4.1/css/buttons.bootstrap5.min.css">
   <link href="style.css" rel="stylesheet">
 </head>
 <body class="d-flex min-vh-100 bg-light text-dark">
@@ -19,7 +21,8 @@
       <h4 class="mb-4">Lista de Produtos</h4>
       <div class="card shadow-sm">
         <div class="card-body">
-          <table class="table table-bordered table-striped">
+          <div class="table-responsive">
+          <table class="table table-bordered table-striped" id="tabelaProdutos">
             <thead class="table-light">
               <tr>
                 <th>#</th>
@@ -53,6 +56,7 @@
               </tr>
             </tbody>
           </table>
+          </div>
         </div>
       </div>
     </div>
@@ -61,6 +65,29 @@
 
   <!-- Scripts -->
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="https://code.jquery.com/jquery-3.7.0.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
+  <script src="https://cdn.datatables.net/buttons/2.4.1/js/dataTables.buttons.min.js"></script>
+  <script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.bootstrap5.min.js"></script>
+  <script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.html5.min.js"></script>
+  <script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.print.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.3/jszip.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/pdfmake.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/vfs_fonts.js"></script>
+  <script>
+    $(document).ready(function () {
+      if (!$.fn.DataTable.isDataTable('#tabelaProdutos')) {
+        $('#tabelaProdutos').DataTable({
+          dom: 'Bfrtip',
+          buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
+          language: {
+            url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json'
+          }
+        });
+      }
+    });
+  </script>
   <script src="layout.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add DataTables to product list with search, filters and export buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b07acf1dc832d961f1f3c66027491