### PR TITLE
Adicionar páginas de fluxo de caixa e relatórios

### DIFF
--- a/fluxo_caixa.html
+++ b/fluxo_caixa.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Fluxo de Caixa | SIGE</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/buttons/2.4.1/css/buttons.bootstrap5.min.css">
+  <link href="style.css" rel="stylesheet">
+</head>
+<body class="d-flex min-vh-100 bg-light text-dark">
+
+  <div id="sidebar-container"></div>
+
+  <div class="content">
+    <div id="navbar-container"></div>
+
+    <div class="container mt-5">
+      <div class="d-flex justify-content-between align-items-center mb-4">
+        <h3>Fluxo de Caixa</h3>
+        <a href="index.html" class="btn btn-secondary"><i class="bi bi-arrow-left"></i> Voltar</a>
+      </div>
+
+      <div class="card mb-4">
+        <div class="card-body">
+          <h5 class="card-title">Saldo Atual</h5>
+          <p class="card-text fs-4">Kz 115.000</p>
+        </div>
+      </div>
+
+      <div class="table-responsive">
+        <table class="table table-striped table-hover align-middle" id="tabelaFluxo">
+          <thead class="table-light">
+            <tr>
+              <th>Data</th>
+              <th>Descrição</th>
+              <th>Tipo</th>
+              <th>Valor (Kz)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>01/08/2025</td>
+              <td>Venda de Produto X</td>
+              <td><span class="badge bg-success">Entrada</span></td>
+              <td>15000</td>
+            </tr>
+            <tr>
+              <td>02/08/2025</td>
+              <td>Pagamento de Fornecedor Y</td>
+              <td><span class="badge bg-danger">Saída</span></td>
+              <td>5000</td>
+            </tr>
+            <tr>
+              <td>03/08/2025</td>
+              <td>Venda de Serviço Z</td>
+              <td><span class="badge bg-success">Entrada</span></td>
+              <td>8000</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="https://code.jquery.com/jquery-3.7.0.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
+  <script src="https://cdn.datatables.net/buttons/2.4.1/js/dataTables.buttons.min.js"></script>
+  <script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.bootstrap5.min.js"></script>
+  <script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.html5.min.js"></script>
+  <script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.print.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.3/jszip.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/pdfmake.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/vfs_fonts.js"></script>
+  <script>
+    $(document).ready(function () {
+      $('#tabelaFluxo').DataTable({
+        dom: 'Bfrtip',
+        buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
+        language: {
+          url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json'
+        }
+      });
+    });
+  </script>
+  <script src="layout.js"></script>
+</body>
+</html>

--- a/relatorios_caixa.html
+++ b/relatorios_caixa.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Relatórios de Caixa | SIGE</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/buttons/2.4.1/css/buttons.bootstrap5.min.css">
+  <link href="style.css" rel="stylesheet">
+</head>
+<body class="d-flex min-vh-100 bg-light text-dark">
+
+  <div id="sidebar-container"></div>
+
+  <div class="content">
+    <div id="navbar-container"></div>
+
+    <div class="container mt-5">
+      <div class="d-flex justify-content-between align-items-center mb-4">
+        <h3>Relatórios de Caixa</h3>
+        <a href="index.html" class="btn btn-secondary"><i class="bi bi-arrow-left"></i> Voltar</a>
+      </div>
+
+      <div class="table-responsive">
+        <table class="table table-striped table-hover align-middle" id="tabelaRelCaixa">
+          <thead class="table-light">
+            <tr>
+              <th>Período</th>
+              <th>Entradas (Kz)</th>
+              <th>Saídas (Kz)</th>
+              <th>Saldo (Kz)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>01-07/08/2025</td>
+              <td>40000</td>
+              <td>15000</td>
+              <td>25000</td>
+            </tr>
+            <tr>
+              <td>08-14/08/2025</td>
+              <td>35000</td>
+              <td>10000</td>
+              <td>25000</td>
+            </tr>
+            <tr>
+              <td>15-21/08/2025</td>
+              <td>30000</td>
+              <td>18000</td>
+              <td>12000</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="https://code.jquery.com/jquery-3.7.0.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
+  <script src="https://cdn.datatables.net/buttons/2.4.1/js/dataTables.buttons.min.js"></script>
+  <script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.bootstrap5.min.js"></script>
+  <script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.html5.min.js"></script>
+  <script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.print.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.3/jszip.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/pdfmake.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/vfs_fonts.js"></script>
+  <script>
+    $(document).ready(function () {
+      $('#tabelaRelCaixa').DataTable({
+        dom: 'Bfrtip',
+        buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
+        language: {
+          url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json'
+        }
+      });
+    });
+  </script>
+  <script src="layout.js"></script>
+</body>
+</html>

--- a/relatorios_fiscais.html
+++ b/relatorios_fiscais.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Relatórios Fiscais | SIGE</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/buttons/2.4.1/css/buttons.bootstrap5.min.css">
+  <link href="style.css" rel="stylesheet">
+</head>
+<body class="d-flex min-vh-100 bg-light text-dark">
+
+  <div id="sidebar-container"></div>
+
+  <div class="content">
+    <div id="navbar-container"></div>
+
+    <div class="container mt-5">
+      <div class="d-flex justify-content-between align-items-center mb-4">
+        <h3>Relatórios Fiscais</h3>
+        <a href="index.html" class="btn btn-secondary"><i class="bi bi-arrow-left"></i> Voltar</a>
+      </div>
+
+      <div class="table-responsive">
+        <table class="table table-striped table-hover align-middle" id="tabelaFiscais">
+          <thead class="table-light">
+            <tr>
+              <th>Mês</th>
+              <th>Vendas Brutas (Kz)</th>
+              <th>IVA (14%)</th>
+              <th>Situação</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Julho/2025</td>
+              <td>150000</td>
+              <td>21000</td>
+              <td><span class="badge bg-success">Entregue</span></td>
+            </tr>
+            <tr>
+              <td>Agosto/2025</td>
+              <td>180000</td>
+              <td>25200</td>
+              <td><span class="badge bg-warning text-dark">Pendente</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="https://code.jquery.com/jquery-3.7.0.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
+  <script src="https://cdn.datatables.net/buttons/2.4.1/js/dataTables.buttons.min.js"></script>
+  <script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.bootstrap5.min.js"></script>
+  <script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.html5.min.js"></script>
+  <script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.print.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.3/jszip.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/pdfmake.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/vfs_fonts.js"></script>
+  <script>
+    $(document).ready(function () {
+      $('#tabelaFiscais').DataTable({
+        dom: 'Bfrtip',
+        buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
+        language: {
+          url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json'
+        }
+      });
+    });
+  </script>
+  <script src="layout.js"></script>
+</body>
+</html>

--- a/relatorios_vendas.html
+++ b/relatorios_vendas.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Relatórios de Vendas | SIGE</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css">
+  <link rel="stylesheet" href="https://cdn.datatables.net/buttons/2.4.1/css/buttons.bootstrap5.min.css">
+  <link href="style.css" rel="stylesheet">
+</head>
+<body class="d-flex min-vh-100 bg-light text-dark">
+
+  <div id="sidebar-container"></div>
+
+  <div class="content">
+    <div id="navbar-container"></div>
+
+    <div class="container mt-5">
+      <div class="d-flex justify-content-between align-items-center mb-4">
+        <h3>Relatórios de Vendas</h3>
+        <a href="index.html" class="btn btn-secondary"><i class="bi bi-arrow-left"></i> Voltar</a>
+      </div>
+
+      <div class="table-responsive">
+        <table class="table table-striped table-hover align-middle" id="tabelaVendas">
+          <thead class="table-light">
+            <tr>
+              <th>Produto</th>
+              <th>Cliente</th>
+              <th>Vendedor</th>
+              <th>Data</th>
+              <th>Valor (Kz)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Produto A</td>
+              <td>João Silva</td>
+              <td>Maria</td>
+              <td>01/08/2025</td>
+              <td>12000</td>
+            </tr>
+            <tr>
+              <td>Produto B</td>
+              <td>Pedro Cardoso</td>
+              <td>José</td>
+              <td>02/08/2025</td>
+              <td>8000</td>
+            </tr>
+            <tr>
+              <td>Serviço C</td>
+              <td>Maria Fernandes</td>
+              <td>Luisa</td>
+              <td>03/08/2025</td>
+              <td>5000</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="https://code.jquery.com/jquery-3.7.0.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
+  <script src="https://cdn.datatables.net/buttons/2.4.1/js/dataTables.buttons.min.js"></script>
+  <script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.bootstrap5.min.js"></script>
+  <script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.html5.min.js"></script>
+  <script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.print.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.1.3/jszip.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/pdfmake.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/vfs_fonts.js"></script>
+  <script>
+    $(document).ready(function () {
+      $('#tabelaVendas').DataTable({
+        dom: 'Bfrtip',
+        buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
+        language: {
+          url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json'
+        }
+      });
+    });
+  </script>
+  <script src="layout.js"></script>
+</body>
+</html>

--- a/sidebar.html
+++ b/sidebar.html
@@ -30,8 +30,16 @@
       <a href="lista_produtos.html" class="nav-link text-white">Lista de Produtos</a>
       <a href="adicionar_produto.html" class="nav-link text-white">Adicionar Produtos</a>
     </div>
-    <a href="#" class="nav-link text-white"><i class="bi bi-cash-coin me-2"></i>Caixa</a>
-    <a href="#" class="nav-link text-white"><i class="bi bi-bar-chart me-2"></i>Relatórios</a>
+    <a href="fluxo_caixa.html" class="nav-link text-white"><i class="bi bi-cash-coin me-2"></i>Fluxo de Caixa</a>
+    <a class="nav-link text-white d-flex justify-content-between align-items-center" data-bs-toggle="collapse" href="#submenuRelatorios" role="button" aria-expanded="false" aria-controls="submenuRelatorios">
+      <span><i class="bi bi-bar-chart me-2"></i>Relatórios</span>
+      <i class="bi bi-caret-down"></i>
+    </a>
+    <div class="collapse ms-3" id="submenuRelatorios" data-bs-parent="#sidebar-menu">
+      <a href="relatorios_vendas.html" class="nav-link text-white">Relatórios de Vendas</a>
+      <a href="relatorios_caixa.html" class="nav-link text-white">Relatórios de Caixa</a>
+      <a href="relatorios_fiscais.html" class="nav-link text-white">Relatórios Fiscais</a>
+    </div>
     <a href="#" class="nav-link text-white"><i class="bi bi-gear me-2"></i>Configurações</a>
     <a href="#" class="nav-link text-white"><i class="bi bi-box-arrow-right me-2"></i>Sair</a>
   </nav>


### PR DESCRIPTION
## Summary
- Criadas páginas para Fluxo de Caixa e Relatórios (vendas, caixa e fiscais) com tabelas exportáveis
- Atualizado o menu lateral para incluir os novos links e submenu de relatórios

## Testing
- `npm test` *(falhou: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b1a303e38832d82bfa48db8ad1416