### PR TITLE
Melhora filtros e comparativo do fluxo de caixa

### DIFF
--- a/fluxo_caixa.html
+++ b/fluxo_caixa.html
@@ -40,11 +40,22 @@
           <option value="week">Semana</option>
           <option value="month">Mês</option>
         </select>
+        <div id="subFiltro" class="mt-2" style="display:none;"></div>
       </div>
 
       <div class="card mb-4">
         <div class="card-body">
-          <h5 class="card-title">Comparativo de Entradas e Saídas</h5>
+          <h5 class="card-title">Comparativo de Períodos</h5>
+          <div class="mb-3">
+            <label for="tipoComparativo" class="form-label">Comparar:</label>
+            <select id="tipoComparativo" class="form-select d-inline w-auto">
+              <option value="day">Dia</option>
+              <option value="week">Semana</option>
+              <option value="month">Mês</option>
+            </select>
+            <span id="comparativoInputs"></span>
+          </div>
+          <p id="resultadoComparativo" class="fw-bold"></p>
           <canvas id="fluxoChart" height="100"></canvas>
         </div>
       </div>
@@ -124,7 +135,6 @@
       }
 
       adicionarDadosFicticios();
-
       function calcularTotais() {
         let entradas = 0, saidas = 0;
         tabela.rows({ filter: 'applied' }).every(function () {
@@ -139,86 +149,141 @@
         $('#saldoAtual').text(`Kz ${(entradas - saidas).toLocaleString()}`);
       }
 
-      function aplicarFiltro(periodo) {
+      function weekToDate(year, week) {
+        const simple = new Date(year, 0, 1 + (week - 1) * 7);
+        const dow = simple.getDay();
+        const ISOweekStart = new Date(simple);
+        if (dow <= 4) ISOweekStart.setDate(simple.getDate() - dow + 1);
+        else ISOweekStart.setDate(simple.getDate() + 8 - dow);
+        return ISOweekStart;
+      }
+
+      function aplicarFiltro(periodo, valor) {
         $.fn.dataTable.ext.search = $.fn.dataTable.ext.search.filter(f => !f._periodoFilter);
-        if (periodo === 'all') return;
-        const now = new Date();
-        const startWeek = new Date(now);
-        startWeek.setDate(now.getDate() - now.getDay());
-        const endWeek = new Date(startWeek);
-        endWeek.setDate(startWeek.getDate() + 6);
+        if (periodo === 'all' || !valor) { tabela.draw(); return; }
         const filterFunc = function (settings, data) {
           const [d, m, y] = data[0].split('/').map(Number);
           const rowDate = new Date(y, m - 1, d);
           if (periodo === 'day') {
-            return rowDate.toDateString() === now.toDateString();
+            const sel = new Date(valor);
+            return rowDate.toDateString() === sel.toDateString();
           } else if (periodo === 'week') {
-            return rowDate >= startWeek && rowDate <= endWeek;
+            const [year, wk] = valor.split('-W').map(Number);
+            const start = weekToDate(year, wk);
+            const end = new Date(start);
+            end.setDate(start.getDate() + 6);
+            return rowDate >= start && rowDate <= end;
           } else if (periodo === 'month') {
-            return rowDate.getMonth() === now.getMonth() && rowDate.getFullYear() === now.getFullYear();
+            const [year, month] = valor.split('-').map(Number);
+            return rowDate.getFullYear() === year && (rowDate.getMonth() + 1) === month;
           }
           return true;
         };
         filterFunc._periodoFilter = true;
         $.fn.dataTable.ext.search.push(filterFunc);
+        tabela.draw();
+      }
+
+      $('#filtroPeriodo').on('change', function () {
+        mostrarSubFiltro(this.value);
+        const val = $('#subFiltro input').val();
+        aplicarFiltro(this.value, val);
+      });
+
+      $('#subFiltro').on('change', 'input', function () {
+        const periodo = $('#filtroPeriodo').val();
+        aplicarFiltro(periodo, this.value);
+      });
+
+      function mostrarSubFiltro(periodo) {
+        let html = '';
+        if (periodo === 'day') html = '<input type="date" class="form-control w-auto" />';
+        else if (periodo === 'week') html = '<input type="week" class="form-control w-auto" />';
+        else if (periodo === 'month') html = '<input type="month" class="form-control w-auto" />';
+        $('#subFiltro').html(html).toggle(periodo !== 'all');
       }
 
       const ctx = document.getElementById('fluxoChart').getContext('2d');
-      let fluxoChart;
-      function atualizarGrafico() {
-        const totals = { day: { e: 0, s: 0 }, week: { e: 0, s: 0 }, month: { e: 0, s: 0 } };
-        const now = new Date();
-        const startWeek = new Date(now);
-        startWeek.setDate(now.getDate() - now.getDay());
-        const endWeek = new Date(startWeek);
-        endWeek.setDate(startWeek.getDate() + 6);
+      let comparativoChart;
 
+      function mostrarInputsComparativo(tipo) {
+        let html = '';
+        if (tipo === 'day') html = '<input type="date" id="compInput1" class="form-control d-inline w-auto me-2" /> <input type="date" id="compInput2" class="form-control d-inline w-auto" />';
+        else if (tipo === 'week') html = '<input type="week" id="compInput1" class="form-control d-inline w-auto me-2" /> <input type="week" id="compInput2" class="form-control d-inline w-auto" />';
+        else if (tipo === 'month') html = '<input type="month" id="compInput1" class="form-control d-inline w-auto me-2" /> <input type="month" id="compInput2" class="form-control d-inline w-auto" />';
+        $('#comparativoInputs').html(html);
+      }
+
+      function obterSaldoPeriodo(tipo, valor) {
+        let start, end;
+        if (tipo === 'day') {
+          start = end = new Date(valor);
+        } else if (tipo === 'week') {
+          const [year, wk] = valor.split('-W').map(Number);
+          start = weekToDate(year, wk);
+          end = new Date(start);
+          end.setDate(start.getDate() + 6);
+        } else if (tipo === 'month') {
+          const [year, month] = valor.split('-').map(Number);
+          start = new Date(year, month - 1, 1);
+          end = new Date(year, month, 0);
+        }
+        let entradas = 0, saidas = 0;
         tabela.rows().every(function () {
           const data = this.data();
           const tipo = $('<div>').html(data[2]).text().trim();
           const valor = parseFloat(data[3]);
           const [d, m, y] = data[0].split('/').map(Number);
           const rowDate = new Date(y, m - 1, d);
-          const entrada = tipo === 'Entrada';
-          if (rowDate.toDateString() === now.toDateString()) {
-            entrada ? totals.day.e += valor : totals.day.s += valor;
-          }
-          if (rowDate >= startWeek && rowDate <= endWeek) {
-            entrada ? totals.week.e += valor : totals.week.s += valor;
-          }
-          if (rowDate.getMonth() === now.getMonth() && rowDate.getFullYear() === now.getFullYear()) {
-            entrada ? totals.month.e += valor : totals.month.s += valor;
+          if (rowDate >= start && rowDate <= end) {
+            if (tipo === 'Entrada') entradas += valor;
+            else if (tipo === 'Saída') saidas += valor;
           }
         });
+        return entradas - saidas;
+      }
 
+      function formatLabel(tipo, valor) {
+        if (tipo === 'day') return new Date(valor).toLocaleDateString('pt-PT');
+        if (tipo === 'week') {
+          const [year, wk] = valor.split('-W');
+          return `Sem ${wk}/${year}`;
+        }
+        if (tipo === 'month') {
+          const [year, month] = valor.split('-');
+          return `${month}/${year}`;
+        }
+      }
+
+      function atualizarGraficoComparativo() {
+        const tipo = $('#tipoComparativo').val();
+        const v1 = $('#compInput1').val();
+        const v2 = $('#compInput2').val();
+        if (!v1 || !v2) return;
+        const total1 = obterSaldoPeriodo(tipo, v1);
+        const total2 = obterSaldoPeriodo(tipo, v2);
+        const perc = total1 !== 0 ? ((total2 - total1) / total1) * 100 : 0;
+        $('#resultadoComparativo').text(`Desempenho: ${perc.toFixed(2)}%`);
         const dataChart = {
-          labels: ['Dia', 'Semana', 'Mês'],
-          datasets: [
-            { label: 'Entradas', data: [totals.day.e, totals.week.e, totals.month.e], backgroundColor: 'rgba(75, 192, 192, 0.5)' },
-            { label: 'Saídas', data: [totals.day.s, totals.week.s, totals.month.s], backgroundColor: 'rgba(255, 99, 132, 0.5)' }
-          ]
+          labels: [formatLabel(tipo, v1), formatLabel(tipo, v2)],
+          datasets: [{ label: 'Saldo Líquido', data: [total1, total2], backgroundColor: ['rgba(75, 192, 192, 0.5)', 'rgba(255, 99, 132, 0.5)'] }]
         };
-
-        if (fluxoChart) fluxoChart.destroy();
-        fluxoChart = new Chart(ctx, { type: 'bar', data: dataChart, options: { responsive: true } });
+        if (comparativoChart) comparativoChart.destroy();
+        comparativoChart = new Chart(ctx, { type: 'bar', data: dataChart, options: { responsive: true } });
       }
 
-      function atualizar() {
-        calcularTotais();
-        atualizarGrafico();
-      }
-
-      $('#filtroPeriodo').on('change', function () {
-        aplicarFiltro(this.value);
-        tabela.draw();
-        atualizar();
+      $('#tipoComparativo').on('change', function () {
+        mostrarInputsComparativo(this.value);
       });
+
+      $('#comparativoInputs').on('change', 'input', atualizarGraficoComparativo);
 
       tabela.on('draw', function () {
         calcularTotais();
       });
 
-      atualizar();
+      mostrarInputsComparativo('day');
+      calcularTotais();
     });
   </script>
   <script src="layout.js"></script>


### PR DESCRIPTION
## Resumo
- Permite filtrar o fluxo de caixa por dia, semana ou mês com seleção personalizada de datas
- Adiciona gráfico para comparar períodos distintos com cálculo de desempenho percentual

## Testes
- `npm test` *(falhou: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b2944d128832d993b13e32e35ebde