### PR TITLE
Add search filters to sale dropdowns

### DIFF
--- a/nova_venda.html
+++ b/nova_venda.html
@@ -29,12 +29,14 @@
             </div>
             <div class="mb-3">
               <label for="clienteVenda" class="form-label">Cliente</label>
+              <input type="text" class="form-control mb-2" id="clienteSearch" placeholder="Pesquisar cliente">
               <select class="form-select" id="clienteVenda" required>
                 <option value="">Selecione um cliente</option>
               </select>
             </div>
             <div class="mb-3">
               <label for="produtoVenda" class="form-label">Produto/Serviço</label>
+              <input type="text" class="form-control mb-2" id="produtoSearch" placeholder="Pesquisar produto">
               <select class="form-select" id="produtoVenda" required>
                 <option value="">Selecione um produto</option>
               </select>
@@ -92,6 +94,24 @@
       servicoOption.value = 'servico';
       servicoOption.textContent = 'Adicionar Serviço';
       produtoSelect.appendChild(servicoOption);
+
+      const clienteSearch = document.getElementById('clienteSearch');
+      clienteSearch.addEventListener('input', function() {
+        const termo = this.value.toLowerCase();
+        Array.from(clienteSelect.options).forEach(opt => {
+          if (!opt.value) return;
+          opt.hidden = !opt.textContent.toLowerCase().includes(termo);
+        });
+      });
+
+      const produtoSearch = document.getElementById('produtoSearch');
+      produtoSearch.addEventListener('input', function() {
+        const termo = this.value.toLowerCase();
+        Array.from(produtoSelect.options).forEach(opt => {
+          if (!opt.value) return;
+          opt.hidden = !opt.textContent.toLowerCase().includes(termo);
+        });
+      });
 
       const valorInput = document.getElementById('valorVenda');
       const descDiv = document.getElementById('servicoDescricaoDiv');


### PR DESCRIPTION
## Summary
- add search inputs for client and product selectors on new sale form
- implement filtering logic to show matching options as user types

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b3b8b6458832d86caf25b8f538366