### PR TITLE
Integrate DataTables dropdown and filter with Bootstrap flex

### DIFF
--- a/lista_clientes.html
+++ b/lista_clientes.html
@@ -126,7 +126,7 @@
     $(document).ready(function () {
       if (!$.fn.DataTable.isDataTable('#tabelaClientes')) {
         $('#tabelaClientes').DataTable({
-          dom: 'Bfrtip',
+          dom: "<'d-flex justify-content-between align-items-center flex-wrap mb-3'<'d-flex align-items-center gap-2'lf>B>rtip",
           buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
           language: {
             url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json'

--- a/lista_produtos.html
+++ b/lista_produtos.html
@@ -135,7 +135,7 @@
     $(document).ready(function () {
       if (!$.fn.DataTable.isDataTable('#tabelaProdutos')) {
         $('#tabelaProdutos').DataTable({
-          dom: 'Bfrtip',
+          dom: "<'d-flex justify-content-between align-items-center flex-wrap mb-3'<'d-flex align-items-center gap-2'lf>B>rtip",
           buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
           language: {
             url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json'

--- a/relatorios_caixa.html
+++ b/relatorios_caixa.html
@@ -72,7 +72,7 @@
   <script>
     $(document).ready(function () {
       $('#tabelaRelCaixa').DataTable({
-        dom: 'Bfrtip',
+        dom: "<'d-flex justify-content-between align-items-center flex-wrap mb-3'<'d-flex align-items-center gap-2'lf>B>rtip",
         buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
         language: {
           url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json'

--- a/relatorios_fiscais.html
+++ b/relatorios_fiscais.html
@@ -66,7 +66,7 @@
   <script>
     $(document).ready(function () {
       $('#tabelaFiscais').DataTable({
-        dom: 'Bfrtip',
+        dom: "<'d-flex justify-content-between align-items-center flex-wrap mb-3'<'d-flex align-items-center gap-2'lf>B>rtip",
         buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
         language: {
           url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json'

--- a/relatorios_vendas.html
+++ b/relatorios_vendas.html
@@ -76,7 +76,7 @@
   <script>
     $(document).ready(function () {
       $('#tabelaVendas').DataTable({
-        dom: 'Bfrtip',
+        dom: "<'d-flex justify-content-between align-items-center flex-wrap mb-3'<'d-flex align-items-center gap-2'lf>B>rtip",
         buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
         language: {
           url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json'


### PR DESCRIPTION
## Summary
- Arrange DataTables length dropdown and search filter together using Bootstrap flex utilities
- Apply unified layout across product, client and report pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c8bbf08a0832d9af0bda7d9dd0a50