### PR TITLE
Remove DataTables search filter and dropdown

### DIFF
--- a/lista_clientes.html
+++ b/lista_clientes.html
@@ -125,15 +125,15 @@
   <script>
     $(document).ready(function () {
       if (!$.fn.DataTable.isDataTable('#tabelaClientes')) {
-        $('#tabelaClientes').DataTable({
-          dom: "<'d-flex justify-content-between align-items-center flex-wrap mb-3'<'d-flex align-items-center gap-2'lf>B>rtip",
-          buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
-          language: {
-            url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json'
-          }
-        });
-      }
-    });
+          $('#tabelaClientes').DataTable({
+            dom: "<'d-flex justify-content-between align-items-center flex-wrap mb-3'B>rtip",
+            buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
+            language: {
+              url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json'
+            }
+          });
+        }
+      });
 
     function excluirCliente(id) {
       if (confirm('Tem certeza que deseja excluir este cliente?')) {

--- a/lista_produtos.html
+++ b/lista_produtos.html
@@ -134,13 +134,13 @@
   <script>
     $(document).ready(function () {
       if (!$.fn.DataTable.isDataTable('#tabelaProdutos')) {
-        $('#tabelaProdutos').DataTable({
-          dom: "<'d-flex justify-content-between align-items-center flex-wrap mb-3'<'d-flex align-items-center gap-2'lf>B>rtip",
-          buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
-          language: {
-            url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json'
-          }
-        });
+          $('#tabelaProdutos').DataTable({
+            dom: "<'d-flex justify-content-between align-items-center flex-wrap mb-3'B>rtip",
+            buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
+            language: {
+              url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json'
+            }
+          });
       }
     });
   </script>

--- a/relatorios_caixa.html
+++ b/relatorios_caixa.html
@@ -71,14 +71,14 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/vfs_fonts.js"></script>
   <script>
     $(document).ready(function () {
-      $('#tabelaRelCaixa').DataTable({
-        dom: "<'d-flex justify-content-between align-items-center flex-wrap mb-3'<'d-flex align-items-center gap-2'lf>B>rtip",
-        buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
-        language: {
-          url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json'
-        }
+        $('#tabelaRelCaixa').DataTable({
+          dom: "<'d-flex justify-content-between align-items-center flex-wrap mb-3'B>rtip",
+          buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
+          language: {
+            url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json'
+          }
+        });
       });
-    });
   </script>
   <script src="layout.js"></script>
 </body>

--- a/relatorios_fiscais.html
+++ b/relatorios_fiscais.html
@@ -65,14 +65,14 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/vfs_fonts.js"></script>
   <script>
     $(document).ready(function () {
-      $('#tabelaFiscais').DataTable({
-        dom: "<'d-flex justify-content-between align-items-center flex-wrap mb-3'<'d-flex align-items-center gap-2'lf>B>rtip",
-        buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
-        language: {
-          url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json'
-        }
+        $('#tabelaFiscais').DataTable({
+          dom: "<'d-flex justify-content-between align-items-center flex-wrap mb-3'B>rtip",
+          buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
+          language: {
+            url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json'
+          }
+        });
       });
-    });
   </script>
   <script src="layout.js"></script>
 </body>

--- a/relatorios_vendas.html
+++ b/relatorios_vendas.html
@@ -75,14 +75,14 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/vfs_fonts.js"></script>
   <script>
     $(document).ready(function () {
-      $('#tabelaVendas').DataTable({
-        dom: "<'d-flex justify-content-between align-items-center flex-wrap mb-3'<'d-flex align-items-center gap-2'lf>B>rtip",
-        buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
-        language: {
-          url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json'
-        }
+        $('#tabelaVendas').DataTable({
+          dom: "<'d-flex justify-content-between align-items-center flex-wrap mb-3'B>rtip",
+          buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
+          language: {
+            url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json'
+          }
+        });
       });
-    });
   </script>
   <script src="layout.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- remove built-in DataTables search box and length dropdown from product and client lists and report pages

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c97acea80832d8724d97839e375e4