### PR TITLE
Adiciona filtro de período nos relatórios

### DIFF
--- a/relatorios_caixa.html
+++ b/relatorios_caixa.html
@@ -23,6 +23,17 @@
         <a href="index.html" class="btn btn-secondary"><i class="bi bi-arrow-left"></i> Voltar</a>
       </div>
 
+      <div class="mb-3">
+        <label for="filtroCaixa" class="form-label">Filtrar por:</label>
+        <select id="filtroCaixa" class="form-select w-auto">
+          <option value="tudo" selected>Tudo</option>
+          <option value="dia">Dia</option>
+          <option value="semana">Semana</option>
+          <option value="mes">Mês</option>
+          <option value="ano">Ano</option>
+        </select>
+      </div>
+
       <div class="table-responsive">
         <table class="table table-striped table-hover align-middle" id="tabelaRelCaixa">
           <thead class="table-light">
@@ -71,12 +82,64 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/vfs_fonts.js"></script>
   <script>
     $(document).ready(function () {
-      $('#tabelaRelCaixa').DataTable({
+      const filtro = $('#filtroCaixa');
+
+      $.fn.dataTable.ext.search.push(function (settings, data) {
+        if (settings.nTable.id !== 'tabelaRelCaixa') {
+          return true;
+        }
+
+        const periodo = filtro.val();
+        if (periodo === 'tudo') {
+          return true;
+        }
+
+        const periodoStr = data[0];
+        const [dias, mes, ano] = periodoStr.split('/');
+        const [inicioDia, fimDia] = dias.split('-').map(Number);
+        const month = parseInt(mes, 10) - 1;
+        const year = parseInt(ano, 10);
+        const inicioPeriodo = new Date(year, month, inicioDia);
+        const fimPeriodo = new Date(year, month, fimDia + 1);
+
+        const hoje = new Date();
+        let inicio, fim;
+
+        switch (periodo) {
+          case 'dia':
+            inicio = new Date(hoje.getFullYear(), hoje.getMonth(), hoje.getDate());
+            fim = new Date(inicio.getFullYear(), inicio.getMonth(), inicio.getDate() + 1);
+            break;
+          case 'semana':
+            const diaSemana = hoje.getDay();
+            inicio = new Date(hoje.getFullYear(), hoje.getMonth(), hoje.getDate() - diaSemana);
+            fim = new Date(inicio.getFullYear(), inicio.getMonth(), inicio.getDate() + 7);
+            break;
+          case 'mes':
+            inicio = new Date(hoje.getFullYear(), hoje.getMonth(), 1);
+            fim = new Date(hoje.getFullYear(), hoje.getMonth() + 1, 1);
+            break;
+          case 'ano':
+            inicio = new Date(hoje.getFullYear(), 0, 1);
+            fim = new Date(hoje.getFullYear() + 1, 0, 1);
+            break;
+          default:
+            return true;
+        }
+
+        return inicioPeriodo < fim && fimPeriodo >= inicio;
+      });
+
+      const tabela = $('#tabelaRelCaixa').DataTable({
         dom: "<'d-flex justify-content-between align-items-center flex-wrap mb-3'<'d-flex align-items-center gap-2'lf>B>rtip",
         buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
         language: {
           url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json'
         }
+      });
+
+      filtro.on('change', function () {
+        tabela.draw();
       });
     });
   </script>

--- a/relatorios_fiscais.html
+++ b/relatorios_fiscais.html
@@ -23,6 +23,17 @@
         <a href="index.html" class="btn btn-secondary"><i class="bi bi-arrow-left"></i> Voltar</a>
       </div>
 
+      <div class="mb-3">
+        <label for="filtroFiscais" class="form-label">Filtrar por:</label>
+        <select id="filtroFiscais" class="form-select w-auto">
+          <option value="tudo" selected>Tudo</option>
+          <option value="dia">Dia</option>
+          <option value="semana">Semana</option>
+          <option value="mes">Mês</option>
+          <option value="ano">Ano</option>
+        </select>
+      </div>
+
       <div class="table-responsive">
         <table class="table table-striped table-hover align-middle" id="tabelaFiscais">
           <thead class="table-light">
@@ -65,12 +76,76 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/vfs_fonts.js"></script>
   <script>
     $(document).ready(function () {
-      $('#tabelaFiscais').DataTable({
+      const filtro = $('#filtroFiscais');
+      const meses = {
+        'Janeiro': 0,
+        'Fevereiro': 1,
+        'Março': 2,
+        'Abril': 3,
+        'Maio': 4,
+        'Junho': 5,
+        'Julho': 6,
+        'Agosto': 7,
+        'Setembro': 8,
+        'Outubro': 9,
+        'Novembro': 10,
+        'Dezembro': 11
+      };
+
+      $.fn.dataTable.ext.search.push(function (settings, data) {
+        if (settings.nTable.id !== 'tabelaFiscais') {
+          return true;
+        }
+
+        const periodo = filtro.val();
+        if (periodo === 'tudo') {
+          return true;
+        }
+
+        const [mesNome, anoStr] = data[0].split('/');
+        const month = meses[mesNome];
+        const year = parseInt(anoStr, 10);
+        const inicioPeriodo = new Date(year, month, 1);
+        const fimPeriodo = new Date(year, month + 1, 1);
+
+        const hoje = new Date();
+        let inicio, fim;
+
+        switch (periodo) {
+          case 'dia':
+            inicio = new Date(hoje.getFullYear(), hoje.getMonth(), hoje.getDate());
+            fim = new Date(inicio.getFullYear(), inicio.getMonth(), inicio.getDate() + 1);
+            break;
+          case 'semana':
+            const diaSemana = hoje.getDay();
+            inicio = new Date(hoje.getFullYear(), hoje.getMonth(), hoje.getDate() - diaSemana);
+            fim = new Date(inicio.getFullYear(), inicio.getMonth(), inicio.getDate() + 7);
+            break;
+          case 'mes':
+            inicio = new Date(hoje.getFullYear(), hoje.getMonth(), 1);
+            fim = new Date(hoje.getFullYear(), hoje.getMonth() + 1, 1);
+            break;
+          case 'ano':
+            inicio = new Date(hoje.getFullYear(), 0, 1);
+            fim = new Date(hoje.getFullYear() + 1, 0, 1);
+            break;
+          default:
+            return true;
+        }
+
+        return inicioPeriodo < fim && fimPeriodo >= inicio;
+      });
+
+      const tabela = $('#tabelaFiscais').DataTable({
         dom: "<'d-flex justify-content-between align-items-center flex-wrap mb-3'<'d-flex align-items-center gap-2'lf>B>rtip",
         buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
         language: {
           url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json'
         }
+      });
+
+      filtro.on('change', function () {
+        tabela.draw();
       });
     });
   </script>

--- a/relatorios_vendas.html
+++ b/relatorios_vendas.html
@@ -23,6 +23,17 @@
         <a href="index.html" class="btn btn-secondary"><i class="bi bi-arrow-left"></i> Voltar</a>
       </div>
 
+      <div class="mb-3">
+        <label for="filtroVendas" class="form-label">Filtrar por:</label>
+        <select id="filtroVendas" class="form-select w-auto">
+          <option value="tudo" selected>Tudo</option>
+          <option value="dia">Dia</option>
+          <option value="semana">Semana</option>
+          <option value="mes">Mês</option>
+          <option value="ano">Ano</option>
+        </select>
+      </div>
+
       <div class="table-responsive">
         <table class="table table-striped table-hover align-middle" id="tabelaVendas">
           <thead class="table-light">
@@ -75,12 +86,60 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.1.53/vfs_fonts.js"></script>
   <script>
     $(document).ready(function () {
-      $('#tabelaVendas').DataTable({
+      const filtro = $('#filtroVendas');
+
+      $.fn.dataTable.ext.search.push(function (settings, data) {
+        if (settings.nTable.id !== 'tabelaVendas') {
+          return true;
+        }
+
+        const periodo = filtro.val();
+        if (periodo === 'tudo') {
+          return true;
+        }
+
+        const dataStr = data[3];
+        const [d, m, a] = dataStr.split('/').map(Number);
+        const dataVenda = new Date(a, m - 1, d);
+
+        const hoje = new Date();
+        let inicio, fim;
+
+        switch (periodo) {
+          case 'dia':
+            inicio = new Date(hoje.getFullYear(), hoje.getMonth(), hoje.getDate());
+            fim = new Date(inicio.getFullYear(), inicio.getMonth(), inicio.getDate() + 1);
+            break;
+          case 'semana':
+            const diaSemana = hoje.getDay();
+            inicio = new Date(hoje.getFullYear(), hoje.getMonth(), hoje.getDate() - diaSemana);
+            fim = new Date(inicio.getFullYear(), inicio.getMonth(), inicio.getDate() + 7);
+            break;
+          case 'mes':
+            inicio = new Date(hoje.getFullYear(), hoje.getMonth(), 1);
+            fim = new Date(hoje.getFullYear(), hoje.getMonth() + 1, 1);
+            break;
+          case 'ano':
+            inicio = new Date(hoje.getFullYear(), 0, 1);
+            fim = new Date(hoje.getFullYear() + 1, 0, 1);
+            break;
+          default:
+            return true;
+        }
+
+        return dataVenda >= inicio && dataVenda < fim;
+      });
+
+      const tabela = $('#tabelaVendas').DataTable({
         dom: "<'d-flex justify-content-between align-items-center flex-wrap mb-3'<'d-flex align-items-center gap-2'lf>B>rtip",
         buttons: ['copy', 'csv', 'excel', 'pdf', 'print'],
         language: {
           url: 'https://cdn.datatables.net/plug-ins/1.13.6/i18n/pt-PT.json'
         }
+      });
+
+      filtro.on('change', function () {
+        tabela.draw();
       });
     });
   </script>


### PR DESCRIPTION
## Summary
- adiciona seletor de período (dia, semana, mês, ano) em Relatórios de Vendas
- adiciona filtro de período similar em Relatórios de Caixa
- adiciona filtro de período em Relatórios Fiscais

## Testing
- `npm test` *(erro esperado: package.json ausente)*

------
https://chatgpt.com/codex/tasks/task_e_689db8041338832d8eac88a06947b105