### PR TITLE
Fix dropdown highlighting to mark only current page

### DIFF
--- a/sidebar.html
+++ b/sidebar.html
@@ -18,8 +18,10 @@
     </a>
     <!-- Submenu de clientes -->
     <div class="collapse ms-3" id="submenuClientes" data-bs-parent="#sidebar-menu">
-      <a href="lista_clientes.html" class="nav-link text-white">Lista de Clientes</a>
-      <a href="cadastrar.html" class="nav-link text-white">Cadastrar Cliente</a>
+      <nav class="nav nav-pills flex-column">
+        <a href="lista_clientes.html" class="nav-link text-white">Lista de Clientes</a>
+        <a href="cadastrar.html" class="nav-link text-white">Cadastrar Cliente</a>
+      </nav>
     </div>
     <a class="nav-link text-white d-flex justify-content-between align-items-center" data-bs-toggle="collapse" href="#submenuProdutos" role="button" aria-expanded="false" aria-controls="submenuProdutos">
       <span><i class="bi bi-box-seam me-2"></i>Produtos</span>
@@ -27,27 +29,33 @@
     </a>
     <!-- Submenu de produtos -->
     <div class="collapse ms-3" id="submenuProdutos" data-bs-parent="#sidebar-menu">
-      <a href="lista_produtos.html" class="nav-link text-white">Lista de Produtos</a>
-      <a href="adicionar_produto.html" class="nav-link text-white">Adicionar Produtos</a>
+      <nav class="nav nav-pills flex-column">
+        <a href="lista_produtos.html" class="nav-link text-white">Lista de Produtos</a>
+        <a href="adicionar_produto.html" class="nav-link text-white">Adicionar Produtos</a>
+      </nav>
     </div>
     <a class="nav-link text-white d-flex justify-content-between align-items-center" data-bs-toggle="collapse" href="#submenuCaixa" role="button" aria-expanded="false" aria-controls="submenuCaixa">
       <span><i class="bi bi-cash-coin me-2"></i>Caixa</span>
       <i class="bi bi-caret-down"></i>
     </a>
     <div class="collapse ms-3" id="submenuCaixa" data-bs-parent="#sidebar-menu">
-      <a href="nova_venda.html" class="nav-link text-white">Nova Venda</a>
-      <a href="fluxo_caixa.html" class="nav-link text-white">Fluxo de Caixa</a>
+      <nav class="nav nav-pills flex-column">
+        <a href="nova_venda.html" class="nav-link text-white">Nova Venda</a>
+        <a href="fluxo_caixa.html" class="nav-link text-white">Fluxo de Caixa</a>
+      </nav>
     </div>
     <a class="nav-link text-white d-flex justify-content-between align-items-center" data-bs-toggle="collapse" href="#submenuRelatorios" role="button" aria-expanded="false" aria-controls="submenuRelatorios">
       <span><i class="bi bi-bar-chart me-2"></i>Relatórios</span>
       <i class="bi bi-caret-down"></i>
     </a>
     <div class="collapse ms-3" id="submenuRelatorios" data-bs-parent="#sidebar-menu">
-      <a href="relatorios_vendas.html" class="nav-link text-white">Relatórios de Vendas</a>
-      <a href="relatorios_caixa.html" class="nav-link text-white">Relatórios de Caixa</a>
-      <a href="relatorios_fiscais.html" class="nav-link text-white">Relatórios Fiscais</a>
+      <nav class="nav nav-pills flex-column">
+        <a href="relatorios_vendas.html" class="nav-link text-white">Relatórios de Vendas</a>
+        <a href="relatorios_caixa.html" class="nav-link text-white">Relatórios de Caixa</a>
+        <a href="relatorios_fiscais.html" class="nav-link text-white">Relatórios Fiscais</a>
         <a href="relatorios_estoque.html" class="nav-link text-white">Relatórios de Estoque</a>
-      </div>
+      </nav>
+    </div>
     <a href="#" class="nav-link text-white"><i class="bi bi-gear me-2"></i>Configurações</a>
     <a href="#" class="nav-link text-white"><i class="bi bi-box-arrow-right me-2"></i>Sair</a>
   </nav>


### PR DESCRIPTION
## Summary
- wrap submenu links in their own nav to stop Bootstrap from styling all links as active when one page is open

## Testing
- `npm install jsdom` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_689dde8173d4832d8de7e5294a49b24c